### PR TITLE
 media: rzg2l-cru: Increase the number of V4L buffers compared to the number of HW slots 

### DIFF
--- a/drivers/media/platform/rzg2l-cru/rzg2l-core.c
+++ b/drivers/media/platform/rzg2l-cru/rzg2l-core.c
@@ -481,11 +481,12 @@ static int rzg2l_cru_s_ctrl(struct v4l2_ctrl *ctrl)
 						 struct rzg2l_cru_dev,
 						 ctrl_handler);
 	int ret = 0;
-
+	cru_dbg(cru,"Number of buffers is being set to %lu \n", HW_BUFFER_DEFAULT);
 	switch (ctrl->id) {
 	case V4L2_CID_MIN_BUFFERS_FOR_CAPTURE:
 		if ((cru->state == STOPPED) || (cru->state == STOPPING))
-			cru->num_buf = ctrl->val;
+			// Always use four buffers so that we have at-least 3x more buffers than slots
+			cru->num_buf = HW_BUFFER_DEFAULT;
 		else
 			ret = -EBUSY;
 
@@ -564,7 +565,7 @@ static int rzg2l_cru_probe(struct platform_device *pdev)
 	v4l2_ctrl_handler_init(&cru->ctrl_handler, 2);
 	ctrl = v4l2_ctrl_new_std(&cru->ctrl_handler, &rzg2l_cru_ctrl_ops,
 			  V4L2_CID_MIN_BUFFERS_FOR_CAPTURE,
-			  2, HW_BUFFER_MAX, 1, HW_BUFFER_DEFAULT);
+			  CRU_V4L_NUM_BUFFERS_MIN, CRU_V4L_NUM_BUFFERS_MAX, 1, CRU_V4L_NUM_BUFFERS_DEFAULT);
 
 	ctrl->flags &= ~V4L2_CTRL_FLAG_READ_ONLY;
 

--- a/drivers/media/platform/rzg2l-cru/rzg2l-cru.h
+++ b/drivers/media/platform/rzg2l-cru/rzg2l-cru.h
@@ -149,6 +149,10 @@ static const struct regs_offset rzv2h_cru_regs_offset[] = {
 #define HW_BUFFER_MAX		8
 #define HW_BUFFER_DEFAULT	4
 
+#define CRU_V4L_NUM_BUFFERS_MIN 12
+#define CRU_V4L_NUM_BUFFERS_MAX 20
+#define CRU_V4L_NUM_BUFFERS_DEFAULT 12
+
 /* Number of HW Bus Transfer Completion Events */
 #define HW_IVT_MAX		5
 

--- a/drivers/media/platform/rzg2l-cru/rzg2l-dma.c
+++ b/drivers/media/platform/rzg2l-cru/rzg2l-dma.c
@@ -435,6 +435,7 @@ static void rzg2l_cru_fill_hw_slot(struct rzg2l_cru_dev *cru, int slot)
 	cru_dbg(cru, "Filling HW slot: %d\n", slot);
 
 	if (list_empty(&cru->buf_list)) {
+		cru_dbg(cru, "Using scratch buffer due to lack of free buffers \n");
 		cru->queue_buf[slot] = NULL;
 		phys_addr = cru->scratch_phys;
 	} else {


### PR DESCRIPTION
g-streamer performs an `V4L2_CID_MIN_BUFFERS_FOR_CAPTURE` IOCTL to workout how many V4L buffers to allocate (https://github.com/GStreamer/gst-plugins-good/blob/20bbeb5e37666c53c254c7b08470ad8a00d97630/sys/v4l2/gstv4l2object.c#L820). The description of this parameter is the following:

> This is a read-only control that can be read by the application and used as a hint to determine the number of CAPTURE buffers to pass to REQBUFS. The value is the minimum number of CAPTURE buffers that is necessary for hardware to work.


Before this patch, there's a 1:1 relationship between the used number of HW slots and the number of V4L buffers. Which means that there's no spare buffers to use for filling in slots after receiving a frame.

After this patch there's 3x more buffers than slots which means that there should always be many spare buffers that can be used for filling in slots after receiving a frame. The downside to this patch is that the number of slots is now hard-coded to be 4. 

A way of reproducing this is issue is by using v4l-ctrl which allows you to control the number of buffers as a command line argument as g-streamer doesn't currently support setting the number of V4L buffers.

**4 V4L buffer/4 slots test:**
```
root@imdt-v2h-sbc:~# v4l2-ctl --stream-mmap=4  --set-fmt-video=width=1280,height=720 -d /dev/video0
<<<<<<<<<<<<<< 15.04 fps, dropped buffers: 3
<<<<<<<<<<<<< 15.93 fps, dropped buffers: 3
<<<<<<<<<<<<<<< 16.82 fps, dropped buffers: 4
<<<<<<<<<<<<<<< 17.42 fps, dropped buffers: 4
```

**12 V4L buffers/4 slots test**

```
root@imdt-v2h-sbc:~# v4l2-ctl --stream-mmap=12  --set-fmt-video=width=1280,height=720 -d /dev/video0
<<<<<<<<<<<<<<<<<<<<< 19.50 fps
<<<<<<<<<<<<<<<<<<<< 19.50 fps
<<<<<<<<<<<<<<<<<<< 19.50 fps
<<<<<<<<<<<<<<<<<<<< 19.50 fps
<<<<<<<
```



